### PR TITLE
feat: Added support for custom weight and edge filtering functions...…

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Laurix1983/k-shortest-path.git"
+    "url": "git+https://github.com/tomer953/k-shortest-path.git"
   },
   "keywords": [
     "ksp",
@@ -21,9 +21,9 @@
   "author": "tomer953",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/Laurix1983/k-shortest-path/issues"
+    "url": "https://github.com/tomer953/k-shortest-path/issues"
   },
-  "homepage": "https://github.com/Laurix1983/k-shortest-path#readme",
+  "homepage": "https://github.com/tomer953/k-shortest-path#readme",
   "dependencies": {
     "graphlib": "^2.1.7"
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tomer953/k-shortest-path.git"
+    "url": "git+https://github.com/Laurix1983/k-shortest-path.git"
   },
   "keywords": [
     "ksp",
@@ -21,9 +21,9 @@
   "author": "tomer953",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/tomer953/k-shortest-path/issues"
+    "url": "https://github.com/Laurix1983/k-shortest-path/issues"
   },
-  "homepage": "https://github.com/tomer953/k-shortest-path#readme",
+  "homepage": "https://github.com/Laurix1983/k-shortest-path#readme",
   "dependencies": {
     "graphlib": "^2.1.7"
   }


### PR DESCRIPTION
…in case you are storing objects in the graph instead of mere values

@tomer953 First of all thanks for a great library. As I had a graphlib object where each node and edge had objects as it's label I had to do small alterations to support this.

My proof of concept was done very quickly and is not probably the most elegant code but I think you get the point from this ;-)

I am basically exposing the graphlib.dijkstra weightFn,and edgeFn capabilities through k-shortest-path. It should be backwards compatible but didn't really test that much.

Also you can ignore all the changes in the package.json as i just had to change those to get my github node building to function